### PR TITLE
linter in build action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,8 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: 1.16
+      - name: Linter
+        uses: golangci/golangci-lint-action@v2
       - name: Test & Coverage
         run: |
           go test -v -race -coverprofile=coverage.txt -covermode=atomic -tags=integration ./...


### PR DESCRIPTION
Try to fix the linter action and make it a mandatory step for each new PR.

Once merged, direct commit's to the `main` repo can be restricted. TBD.