### PR TITLE
fix: remove after-draw redraw loop (idle high CPU)

### DIFF
--- a/internal/tui/events.go
+++ b/internal/tui/events.go
@@ -6,31 +6,6 @@ import (
 	"github.com/gdamore/tcell/v2"
 )
 
-func (tui *TUI) setAfterDrawFunc(screen tcell.Screen) {
-	tui.queueUpdateDraw(func() {
-		p := tui.App.GetFocus()
-
-		tui.Sources.SetBorderColor(tcell.ColorWhite)
-		tui.Schemas.SetBorderColor(tcell.ColorWhite)
-		tui.Tables.SetBorderColor(tcell.ColorWhite)
-		tui.PreviewTable.SetBorderColor(tcell.ColorWhite)
-		tui.QueryInput.SetBorderColor(tcell.ColorWhite)
-
-		switch p {
-		case tui.Sources:
-			tui.Sources.SetBorderColor(tcell.ColorGreen)
-		case tui.Schemas:
-			tui.Schemas.SetBorderColor(tcell.ColorGreen)
-		case tui.Tables:
-			tui.Tables.SetBorderColor(tcell.ColorGreen)
-		case tui.PreviewTable:
-			tui.PreviewTable.SetBorderColor(tcell.ColorGreen)
-		case tui.QueryInput:
-			tui.QueryInput.SetBorderColor(tcell.ColorGreen)
-		}
-	})
-}
-
 func (tui *TUI) sourceSelected(index int, mainText string, secondaryText string, shortcut rune) {
 	err := tui.dc.Switch(mainText)
 	if err != nil {

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -282,7 +282,12 @@ func NewTUI(appConfig internal.AppConfig, dataController internal.DataController
 		AddItem(previewAndQuery, 0, 1, 1, 1, 0, 0, false).
 		AddItem(t.FooterText, 1, 0, 1, 2, 0, 0, false)
 
-	t.App.SetAfterDrawFunc(t.setAfterDrawFunc)
+	// Focus-driven border highlight. An after-draw hook is never an option here:
+	// queueing a draw from it re-fires the hook and the loop spins at 100% CPU (#54).
+	for _, box := range []*tview.Box{t.Sources.Box, t.Schemas.Box, t.Tables.Box, t.PreviewTable.Box, t.QueryInput.Box} {
+		box.SetFocusFunc(func() { box.SetBorderColor(tcell.ColorGreen) })
+		box.SetBlurFunc(func() { box.SetBorderColor(tcell.ColorWhite) })
+	}
 	t.setupKeyboard()
 
 	// TODO: Use-case when config was updated. Reload data sources.


### PR DESCRIPTION
Closes #54. Deletes the SetAfterDrawFunc -> QueueUpdateDraw cycle (every draw queued another draw); border highlight moved to SetFocusFunc/SetBlurFunc. Verified under a pty: idle CPU 6.0% -> 0.0% in demo mode; focused-border green rendering confirmed in captured output.