### PR TITLE
fix: sqlite New() nil-pointer panic on Stat error

### DIFF
--- a/internal/sqlite/sqlite.go
+++ b/internal/sqlite/sqlite.go
@@ -17,7 +17,7 @@ type DataSource struct {
 // New initializes a new SQLite Datasource.
 func New(dsn string) (*DataSource, error) {
 	info, err := os.Stat(dsn)
-	if os.IsNotExist(err) {
+	if err != nil {
 		return nil, err
 	}
 

--- a/internal/sqlite/sqlite_test.go
+++ b/internal/sqlite/sqlite_test.go
@@ -14,6 +14,15 @@ func Test_SQLiteFileNotExist(t *testing.T) {
 	require.Nil(t, ds)
 }
 
+func Test_SQLiteStatError(t *testing.T) {
+	// Parent path is a file, so os.Stat fails with ENOTDIR — a non-NotExist
+	// error that used to nil-deref in New.
+	ds, err := New("testdata/chinook.db/nested")
+
+	require.Error(t, err)
+	require.Nil(t, ds)
+}
+
 func Test_SQLiteDirectory(t *testing.T) {
 	ds, err := New("testdata")
 


### PR DESCRIPTION
Closes #66. `os.IsNotExist(err)` -> `err != nil`; regression test added (ENOTDIR path) — panics on the old code, passes now.