### PR TITLE
fix: non-zero exit codes on failure; errors to stderr; -version flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,37 +4,47 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"path"
-	"time"
+	"path/filepath"
+	"runtime/debug"
 
 	"github.com/kenanbek/dbui/internal/config"
 	"github.com/kenanbek/dbui/internal/controller"
 	"github.com/kenanbek/dbui/internal/tui"
 )
 
+// Set via ldflags by the release pipeline; -version falls back to build info.
 var (
 	version, date string
 )
 
 func main() {
+	os.Exit(run())
+}
+
+func run() int {
 	var (
 		fConfFile string
 		fDemo     bool
 		fConnDSN  string
 		fConnType string
-
-		appConfig *config.AppConfig
+		fVersion  bool
 	)
-
-	fmt.Printf("Starting DBUI v%s (%s) \n", version, date)
 
 	flag.StringVar(&fConfFile, "f", "", "custom configuration file")
 	flag.BoolVar(&fDemo, "demo", false, "run with demo/dummy data source")
 	flag.StringVar(&fConnDSN, "dsn", "", "data source name")
 	flag.StringVar(&fConnType, "type", "", "data source type, used together with -dsn")
+	flag.BoolVar(&fVersion, "version", false, "print version and exit")
 	flag.Parse()
 
-	if fDemo {
+	if fVersion {
+		fmt.Println(versionString())
+		return 0
+	}
+
+	var appConfig *config.AppConfig
+	switch {
+	case fDemo:
 		appConfig = &config.AppConfig{
 			DataSourcesProp: []config.DataSourceConfig{
 				{AliasProp: "demo1", TypeProp: "dummy", DSNProp: "dummy"},
@@ -42,88 +52,70 @@ func main() {
 			},
 			DefaultProp: "demo1",
 		}
-
-		startApp(appConfig)
-		return
-	}
-
-	if fConnDSN != "" {
-		if fConnType == "" {
-			fmt.Println("-dsn and -type flags must be used together")
-			fmt.Println("switching to configuration file mode, trying to load...")
-			time.Sleep(2 * time.Second)
-		} else {
-			appConfig = &config.AppConfig{
-				DataSourcesProp: []config.DataSourceConfig{},
-				DefaultProp:     "custom",
-			}
-			appConfig.DataSourcesProp = append(
-				appConfig.DataSourcesProp,
-				config.DataSourceConfig{AliasProp: "custom", TypeProp: fConnType, DSNProp: fConnDSN},
-			)
-
-			startApp(appConfig)
-			return
+	case fConnDSN != "" || fConnType != "":
+		if fConnDSN == "" || fConnType == "" {
+			fmt.Fprintln(os.Stderr, "-dsn and -type must be used together")
+			return 2
+		}
+		appConfig = &config.AppConfig{
+			DataSourcesProp: []config.DataSourceConfig{
+				{AliasProp: "custom", TypeProp: fConnType, DSNProp: fConnDSN},
+			},
+			DefaultProp: "custom",
+		}
+	default:
+		var err error
+		appConfig, err = readConfig(fConfFile)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return 1
 		}
 	}
-
-	appConfig = readConfig(fConfFile)
-	startApp(appConfig)
-}
-
-func startApp(appConfig *config.AppConfig) {
-	var exitStatus = 1
 
 	ctrl, err := controller.New(appConfig)
 	if err != nil {
-		fmt.Println(err)
-		os.Exit(exitStatus)
+		fmt.Fprintln(os.Stderr, err)
+		return 1
 	}
 
 	t := tui.NewTUI(appConfig, ctrl)
-	err = t.Start()
-	if err != nil {
-		fmt.Printf("failed to start: %v\n", err)
-		os.Exit(exitStatus)
+	if err := t.Start(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to start: %v\n", err)
+		return 1
 	}
+
+	return 0
 }
 
-func readConfig(customConfigFile string) *config.AppConfig {
-	var exitStatus = 0
+func versionString() string {
+	if version != "" {
+		return fmt.Sprintf("dbui %s (%s)", version, date)
+	}
+	if bi, ok := debug.ReadBuildInfo(); ok && bi.Main.Version != "" {
+		return "dbui " + bi.Main.Version
+	}
+	return "dbui (unknown version)"
+}
 
-	var err error
-	var confPath string
-
-	if customConfigFile != "" {
-		if _, err = os.Stat(customConfigFile); err != nil {
-			fmt.Printf("configuration file `%s` does not exists\n", customConfigFile)
-			os.Exit(1)
+func readConfig(customConfigFile string) (*config.AppConfig, error) {
+	confPath := customConfigFile
+	if confPath != "" {
+		if _, err := os.Stat(confPath); err != nil {
+			return nil, fmt.Errorf("configuration file %q does not exist", confPath)
 		}
-		confPath = customConfigFile
 	} else {
 		confPath = "dbui.yml"
-		if _, err = os.Stat(confPath); err != nil {
-			var userDir string
-			userDir, err = os.UserHomeDir()
-			if err != nil {
-				fmt.Println(err)
-				os.Exit(exitStatus)
+		if _, err := os.Stat(confPath); err != nil {
+			userDir, homeErr := os.UserHomeDir()
+			if homeErr != nil {
+				return nil, homeErr
 			}
-
-			confPath = path.Join(userDir, "dbui.yml")
-			if _, err = os.Stat(confPath); err != nil {
-				fmt.Printf("there is no `dbui.yml` file in the current (%s) nor user directory (%s)\n", "./dbui.yml", confPath)
-				fmt.Println("create one or use `-dsn` and `-type` args")
-				os.Exit(exitStatus)
+			confPath = filepath.Join(userDir, "dbui.yml")
+			if _, err := os.Stat(confPath); err != nil {
+				return nil, fmt.Errorf("no dbui.yml in the current or home directory; create one or use -dsn and -type")
 			}
 		}
 	}
 
-	appConfig, err := config.New(confPath)
-	if err != nil {
-		fmt.Println(err)
-		os.Exit(exitStatus)
-	}
-
-	return appConfig
+	return config.New(confPath)
 }


### PR DESCRIPTION
Closes #65. run() int pattern; all failure paths verified by execution: -version exit 0 with build-info fallback, -dsn w/o -type exit 2, missing/bad config exit 1, unsupported type exit 1 — all to stderr. Demo mode smoke-tested under pty.