### PR TITLE
build: brew cask via dedicated homebrew-dbui tap (Apple Silicon support)

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -48,21 +48,25 @@ release:
   draft: true
   prerelease: auto
 
-brews:
+homebrew_casks:
   - name: dbui
     repository:
       owner: KenanBek
-      name: dbui
-    directory: Formula
+      name: homebrew-dbui
+    directory: Casks
     description: "Terminal UI for MySQL, PostgreSQL, and SQLite."
     homepage: "https://github.com/kenanbek/dbui"
-    license: "Apache-2.0"
     commit_author:
       name: KenanBek
       email: mail@kenanbek.me
-    install: bin.install "dbui"
-    test: |
-      system "#{bin}/dbui", "-version"
+    # dbui binaries are unsigned; strip the quarantine bit so Gatekeeper
+    # does not block the cask-installed binary.
+    hooks:
+      post:
+        install: |
+          if system_command("/usr/bin/xattr", args: ["-h"]).exit_status == 0
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/dbui"]
+          end
 
 nfpms:
   - maintainer: KenanBek

--- a/README.md
+++ b/README.md
@@ -62,9 +62,13 @@ with `sudo dpkg -i` and `sudo rpm -i` respectively.
 ### Install
 
 ```shell script
-brew tap kenanbek/dbui https://github.com/kenanbek/dbui
+brew tap kenanbek/dbui
 brew install dbui
 ```
+
+If you tapped the old in-repo location (`brew tap kenanbek/dbui https://github.com/kenanbek/dbui`),
+run `brew untap kenanbek/dbui` once before tapping again — the formula now lives in
+[KenanBek/homebrew-dbui](https://github.com/KenanBek/homebrew-dbui).
 
 Other [installation options](#install). If you have installed the first versions of `dbui`, you might need to un-tap the
 old cask URL. Check [this][wiki-brew-untap] for more information.
@@ -138,9 +142,13 @@ dbui
 #### Option 1: Brew
 
 ```shell script
-brew tap kenanbek/dbui https://github.com/kenanbek/dbui
+brew tap kenanbek/dbui
 brew install dbui
 ```
+
+If you tapped the old in-repo location (`brew tap kenanbek/dbui https://github.com/kenanbek/dbui`),
+run `brew untap kenanbek/dbui` once before tapping again — the formula now lives in
+[KenanBek/homebrew-dbui](https://github.com/KenanBek/homebrew-dbui).
 
 If you have installed the first versions of `dbui`, you might need to un-tap the old cask URL.
 Check [this][wiki-brew-untap] for more information.


### PR DESCRIPTION
Closes #68, refs #48. Replaces wedged #90 (identical diff, fresh PR). brews -> homebrew_casks (on_arm + on_intel, quarantine-strip hook), published to KenanBek/homebrew-dbui; README documents untap/retap. goreleaser check passes clean; snapshot generates the cask with both arch blocks. End-to-end brew install verify happens at the v0.9.0 release.