### PR TITLE
docs+ci: repo hygiene — CONTRIBUTING, SECURITY, README fixes, action bumps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,19 +12,19 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
-      - uses: golangci/golangci-lint-action@v8
+      - uses: golangci/golangci-lint-action@v9
         with:
           version: v2.12.2
 
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
       - name: Unit tests
@@ -39,8 +39,8 @@ jobs:
   integration:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
       - name: Integration and acceptance tests
@@ -49,8 +49,8 @@ jobs:
   vulncheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
       - run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...
@@ -58,10 +58,10 @@ jobs:
   snapshot:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
       - name: Cross-platform snapshot build

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -19,7 +19,7 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: github/codeql-action/init@v4
         with:
           languages: go

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,10 +11,10 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
       - name: Run GoReleaser

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,24 @@
+# Contributing
+
+dbui is a small Go project — contributions are welcome.
+
+## Setup
+
+- Go (version from `go.mod`); Docker for integration tests only.
+- `make test` — unit tests.
+- `make test-integration` — driver + acceptance suites (Docker).
+- `make lint` — golangci-lint (v2 config).
+- `make snapshot` — cross-platform release build via GoReleaser.
+
+## Pull requests
+
+- Keep PRs small and single-purpose; reference the issue they close.
+- Use Conventional Commit messages (`fix:`, `feat:`, `test:`, `ci:`, `docs:`, `chore:`).
+- CI must be green: lint, unit, integration, govulncheck, snapshot.
+- The cross-engine suite in `internal/acceptance` is the contract every
+  `DataSource` change must keep green.
+
+## Roadmap
+
+Work is organized by [milestones](https://github.com/KenanBek/dbui/milestones) —
+pick an issue from the current one.

--- a/README.md
+++ b/README.md
@@ -4,9 +4,8 @@
 with the [tview](https://github.com/rivo/tview).
 
 [![GitHub release (latest by date)](https://img.shields.io/github/v/release/kenanbek/dbui)](https://github.com/KenanBek/dbui/releases/latest)
-[![GitHub Workflow Status](https://img.shields.io/github/workflow/status/kenanbek/dbui/Build)](https://github.com/KenanBek/dbui/actions/workflows/build.yml)
+[![Build](https://img.shields.io/github/actions/workflow/status/kenanbek/dbui/build.yml?branch=main)](https://github.com/KenanBek/dbui/actions/workflows/build.yml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/kenanbek/dbui)](https://goreportcard.com/report/github.com/kenanbek/dbui)
-[![Codecov](https://img.shields.io/codecov/c/github/kenanbek/dbui)](https://app.codecov.io/gh/KenanBek/dbui/)
 
 ![dbui screenshot](docs/dbui.gif "DBUI: CLI for MySQL, PostgreSQL, and SQLite databases")
 
@@ -23,7 +22,7 @@ with the [tview](https://github.com/rivo/tview).
     - full-screen and focus modes,
     - mouse support.
 
-Runs on Mac, Linux, and [Windows](https://kenanbek.gitbook.io/dbui/additional/windows).
+Runs on Mac, Linux, and Windows.
 
 ##### Linux
 
@@ -52,10 +51,7 @@ with `sudo dpkg -i` and `sudo rpm -i` respectively.
 
 ##### Known Issues
 
-- ❗️Critically low amount of tests.
-- ⚠️Having multiple connections and many queries triggers a high CPU load. Now
-  when [this PR](https://github.com/KenanBek/dbui/pull/28) merged, as a next step, I will work on profiling the
-  application.
+- ⚠️The TUI layer has no automated tests yet (planned together with its rewrite).
 
 ## Demo
 
@@ -109,7 +105,7 @@ dataSources:
   - alias: chinook
     type: sqlite
     dsn: "internal/sqlite/testdata/chinook.db"
-defaut: employees
+default: employees
 ```
 
 More about [configuration files](#configuration).
@@ -191,7 +187,7 @@ dataSources:
   - alias: world-db
     type: postgresql
     dsn: "user=world password=world123 host=localhost port=5432 dbname=world-db sslmode=disable"
-defaut: employees
+default: employees
 ```
 
 First, it checks in the current directory, then in the user's home directory.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,14 @@
+# Security Policy
+
+## Supported versions
+
+Only the latest release receives fixes.
+
+## Reporting a vulnerability
+
+Use GitHub's private vulnerability reporting:
+[Report a vulnerability](https://github.com/KenanBek/dbui/security/advisories/new).
+Please do not open public issues for security reports.
+
+dbui connects to databases with credentials you supply; treat your `dbui.yml`
+as a secret file until env/keychain indirection ships (planned for v1.0).

--- a/internal/acceptance/acceptance_integration_test.go
+++ b/internal/acceptance/acceptance_integration_test.go
@@ -126,7 +126,7 @@ func startPostgres(ctx context.Context) (testcontainers.Container, *postgresql.D
 func connectWithRetry[T internal.DataSource](connect func() (T, error)) (T, error) {
 	var ds T
 	var err error
-	deadline := time.Now().Add(2 * time.Minute)
+	deadline := time.Now().Add(5 * time.Minute)
 	for {
 		ds, err = connect()
 		if err == nil {

--- a/internal/mysql/mysql_integration_test.go
+++ b/internal/mysql/mysql_integration_test.go
@@ -56,7 +56,7 @@ func TestMain(m *testing.M) {
 	}
 
 	dsn := fmt.Sprintf("root:demo@(%s:%s)/mysql", host, port.Port())
-	deadline := time.Now().Add(2 * time.Minute)
+	deadline := time.Now().Add(5 * time.Minute)
 	for {
 		db, err = mysql.New(dsn)
 		if err == nil {

--- a/internal/postgresql/postgresql_integration_test.go
+++ b/internal/postgresql/postgresql_integration_test.go
@@ -53,7 +53,7 @@ func TestMain(m *testing.M) {
 	}
 
 	dsn := fmt.Sprintf("user=world password=world123 host=%s port=%s dbname=world-db sslmode=disable", host, port.Port())
-	deadline := time.Now().Add(2 * time.Minute)
+	deadline := time.Now().Add(5 * time.Minute)
 	for {
 		db, err = postgresql.New(dsn)
 		if err == nil {


### PR DESCRIPTION
Closes #69. Issue triage already done repo-side (4 closed with reasons, 2 stale dependabot PRs closed, 19 mapped to milestones/backlog — zero unlabeled open issues). This PR adds the files: CONTRIBUTING, SECURITY (private vuln reporting enabled), README fixes (badges, defaut->default example bug, gitbook link, Known Issues), folds dependabot's action bumps (#86/#88/#89 will auto-close), and fixes the integration-test connect deadline that flaked one main run. Announce rides with the v0.9.0 release notes.