### PR TITLE
ci: dedicated token for cross-repo cask publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,3 +25,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -53,6 +53,7 @@ homebrew_casks:
     repository:
       owner: KenanBek
       name: homebrew-dbui
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
     directory: Casks
     description: "Terminal UI for MySQL, PostgreSQL, and SQLite."
     homepage: "https://github.com/kenanbek/dbui"


### PR DESCRIPTION
The v0.9.0 release's cask push to homebrew-dbui failed with 403 (GITHUB_TOKEN is repo-scoped); the cask was published manually and brew-install verified on Apple Silicon. This wires `HOMEBREW_TAP_GITHUB_TOKEN` with a GITHUB_TOKEN fallback. Requires a fine-grained PAT (contents: write on homebrew-dbui) saved as that secret — see follow-up issue.